### PR TITLE
Implement admin login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ To run this project locally, follow these steps:
     API_KEY=your_api_token
     PORT=8181
     ```
-   The `API_KEY` value is required in the `Authorization` header for any request that creates or deletes posts or comments.
+   The `API_KEY` value is used to authenticate admin actions. Once your server is running, visit `/login` and enter this token to enable creating or deleting posts and comments.
 
 4. **Run database migrations**:  
    Ensure your PostgreSQL server is running and execute:
@@ -141,6 +141,10 @@ To run this project locally, follow these steps:
     ```
 
 The blog will now be accessible at `http://localhost:8181`.
+
+### Admin Login
+
+Navigate to `http://localhost:8181/login` and enter the API key you placed in your `.env` file. Once logged in you can create or delete posts and comments from the UI.
 
 ## Running Tests
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import LandingPage from './components/LandingPage';
 import BlogPosts from './components/BlogPosts';
 import PostDetail from './components/PostDetail';
 import About from './components/About';
+import Login from './components/Login';
 import Navbar from './components/NavBar'; // Navigation bar component
 import './App.css'
 
@@ -16,8 +17,9 @@ const App = () => {
 
         {/* Define the routes */}
         <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/posts" element={<BlogPosts />} />
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/posts" element={<BlogPosts />} />
           <Route path="/posts/:postId" element={<PostDetail />} />
           <Route path="/about" element={<About />} />
         </Routes>

--- a/client/src/__test__/BlogPosts.test.jsx
+++ b/client/src/__test__/BlogPosts.test.jsx
@@ -1,7 +1,8 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import BlogPosts from '../components/BlogPosts'; 
-import { BrowserRouter } from 'react-router-dom'; 
-import { vi, describe, it, expect, beforeEach} from 'vitest'; 
+import BlogPosts from '../components/BlogPosts';
+import { BrowserRouter } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach} from 'vitest';
+import { AuthContext } from '../context/AuthContext';
 
 // Mock fetch API
 global.fetch = vi.fn(() =>
@@ -17,18 +18,22 @@ describe('BlogPosts Component', () => {
 
   it('renders without crashing', () => {
     render(
-      <BrowserRouter>
-        <BlogPosts />
-      </BrowserRouter>
+      <AuthContext.Provider value={{ token: '', login: vi.fn(), logout: vi.fn() }}>
+        <BrowserRouter>
+          <BlogPosts />
+        </BrowserRouter>
+      </AuthContext.Provider>
     );
     expect(screen.getByRole('heading',{ level: 1 })).toBeDefined(/Latest Post/i);
   });
 
   it('fetches and displays posts', async () => {
     render(
-      <BrowserRouter>
-        <BlogPosts />
-      </BrowserRouter>
+      <AuthContext.Provider value={{ token: '', login: vi.fn(), logout: vi.fn() }}>
+        <BrowserRouter>
+          <BlogPosts />
+        </BrowserRouter>
+      </AuthContext.Provider>
     );
 
     await waitFor(() => {

--- a/client/src/__test__/Comments.test.jsx
+++ b/client/src/__test__/Comments.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import Comments from '../components/Comments'; 
+import Comments from '../components/Comments';
 import { vi, describe, expect, it, beforeEach } from 'vitest';
+import { AuthContext } from '../context/AuthContext';
 
 
 global.fetch = vi.fn(() =>
@@ -18,7 +19,11 @@ describe('Comments Component', () => {
   });
 
   it('renders the comments section and fetches comments', async () => {
-    render(<Comments selectedPost={1} />);
+    render(
+      <AuthContext.Provider value={{ token: 'test', login: vi.fn(), logout: vi.fn() }}>
+        <Comments selectedPost={1} />
+      </AuthContext.Provider>
+    );
 
     const toggleButton = screen.getByText(/View Comments/i);
     fireEvent.click(toggleButton);
@@ -39,7 +44,11 @@ describe('Comments Component', () => {
       })
     );
 
-    render(<Comments selectedPost={1} />);
+    render(
+      <AuthContext.Provider value={{ token: 'test', login: vi.fn(), logout: vi.fn() }}>
+        <Comments selectedPost={1} />
+      </AuthContext.Provider>
+    );
 
 
   });
@@ -53,7 +62,11 @@ describe('Comments Component', () => {
       })
     );
 
-    render(<Comments selectedPost={1} />);
+    render(
+      <AuthContext.Provider value={{ token: 'test', login: vi.fn(), logout: vi.fn() }}>
+        <Comments selectedPost={1} />
+      </AuthContext.Provider>
+    );
 
   
   });

--- a/client/src/components/BlogPosts.jsx
+++ b/client/src/components/BlogPosts.jsx
@@ -1,14 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import CreatePost from './CreatePost';
 import '../styles/BlogPosts.css'
+import { AuthContext } from '../context/AuthContext';
 
 const BASE_URL = import.meta.env.VITE_API_URL;
-const API_KEY = import.meta.env.VITE_API_KEY;
 
 const BlogPosts = () => {
     //state management
     const [posts, setPosts] = useState([]);
+    const { token } = useContext(AuthContext);
    
     // Fetch posts on page load
     useEffect(() => {
@@ -31,10 +32,10 @@ const BlogPosts = () => {
 
     // Delete post
     const deletePost = async (postId) => {
-      await fetch(`${BASE_URL}/posts/${postId}`, {
+      await fetch(`${BASE_URL}/api/posts/${postId}`, {
         method: 'DELETE',
         headers: {
-          Authorization: `Bearer ${API_KEY}`,
+          Authorization: `Bearer ${token}`,
         },
       });
       setPosts(posts.filter(post => post.id !== postId));
@@ -54,7 +55,7 @@ const BlogPosts = () => {
               </li>
           ))}
       </ul>
-      <CreatePost addNewPost={addNewPost}/>
+      {token && <CreatePost addNewPost={addNewPost}/>} 
   </div>
     )
 };

--- a/client/src/components/Comments.jsx
+++ b/client/src/components/Comments.jsx
@@ -1,14 +1,15 @@
- import React, { useEffect, useState } from "react";
+ import React, { useEffect, useState, useContext } from "react";
  import '../styles/Comments.css'
+ import { AuthContext } from '../context/AuthContext';
 
  const BASE_URL = import.meta.env.VITE_API_URL;
- const API_KEY = import.meta.env.VITE_API_KEY;
 
 const Comments = ({ selectedPost }) => {
 const [comments, setComments] = useState([])
 const [newComment, setNewComment] = useState('')
 const [newAuthor, setNewAuthor] = useState('')
 const [isExpanded, setIsExpanded] = useState(false);
+const { token } = useContext(AuthContext);
 
     useEffect(() => {
         const fetchCommentsByPostId = async () => {
@@ -44,7 +45,7 @@ const [isExpanded, setIsExpanded] = useState(false);
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${API_KEY}`,
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({ content: newComment, author: newAuthor }),
       });
@@ -83,7 +84,7 @@ const deleteComment = async (commentId, postId) => {
       await fetch(`${BASE_URL}/api/posts/${postId}/comments/${commentId}`, {
         method: 'DELETE',
         headers: {
-          Authorization: `Bearer ${API_KEY}`,
+          Authorization: `Bearer ${token}`,
         },
       });
       setComments(prevComments => prevComments.filter(comment => comment.id !== commentId));

--- a/client/src/components/CreatePost.jsx
+++ b/client/src/components/CreatePost.jsx
@@ -1,13 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import '../styles/CreatePost.css'
+import { AuthContext } from '../context/AuthContext';
 
 const BASE_URL = import.meta.env.VITE_API_URL;
-const API_KEY = import.meta.env.VITE_API_KEY;
 
 const CreatePost = ({ addNewPost }) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [author, setAuthor] = useState('')
+  const [author, setAuthor] = useState('');
+  const { token } = useContext(AuthContext);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -25,7 +26,7 @@ const CreatePost = ({ addNewPost }) => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${API_KEY}`,
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(newPost),
       });

--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+
+const Login = () => {
+  const [tokenInput, setTokenInput] = useState('');
+  const { login } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (tokenInput) {
+      login(tokenInput);
+      setTokenInput('');
+      navigate('/posts');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="login-form">
+      <label>
+        Admin Token:
+        <input
+          type="password"
+          value={tokenInput}
+          onChange={(e) => setTokenInput(e.target.value)}
+        />
+      </label>
+      <button type="submit">Login</button>
+    </form>
+  );
+};
+
+export default Login;

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
 import styles from '../styles/Navbar.module.css';
 
 const Navbar = () => {
+  const { token, logout } = useContext(AuthContext);
   return (
     <nav className={styles.nav}>
       <ul className={styles.list}>
@@ -14,6 +16,13 @@ const Navbar = () => {
         </li>
         <li className={styles.item}>
           <Link className={styles.link} to="/about">About/Contact</Link>
+        </li>
+        <li className={styles.item}>
+          {token ? (
+            <button className={styles.link} onClick={logout}>Logout</button>
+          ) : (
+            <Link className={styles.link} to="/login">Login</Link>
+          )}
         </li>
       </ul>
     </nav>

--- a/client/src/components/PostDetail.jsx
+++ b/client/src/components/PostDetail.jsx
@@ -4,7 +4,6 @@ import Comments from './Comments';
 import '../styles/PostDetail.css'
 
 const BASE_URL = import.meta.env.VITE_API_URL;
-const API_KEY = import.meta.env.VITE_API_KEY;
 
 const PostDetails = () => {
     const { postId } = useParams();

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -1,0 +1,23 @@
+import React, { createContext, useState } from 'react';
+
+export const AuthContext = createContext({ token: '', login: () => {}, logout: () => {} });
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(() => localStorage.getItem('apiToken') || '');
+
+  const login = (newToken) => {
+    setToken(newToken);
+    localStorage.setItem('apiToken', newToken);
+  };
+
+  const logout = () => {
+    setToken('');
+    localStorage.removeItem('apiToken');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -2,12 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { MantineProvider } from '@mantine/core';
 import App from './App.jsx'
+import { AuthProvider } from './context/AuthContext'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <MantineProvider withGlobalStyles withNormalizeCSS>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </MantineProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add new AuthContext and Login component
- integrate AuthProvider into app
- conditionally show CreatePost when logged in
- pass admin token from login for create and delete actions
- fix delete endpoint URL
- document admin login process
- update tests for new auth context

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f7b75d188323ba66d541f839010b