### PR TITLE
Add env flags to disable admin features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.env*

--- a/README.md
+++ b/README.md
@@ -119,15 +119,28 @@ To run this project locally, follow these steps:
     npm install
     ```
 
-3. **Set up environment variables**:  
-   Create a `.env` file in the root directory and add the following values:
-    ```bash
-    DATABASE_URI=your_postgres_database_url
-    OPENAI_API_KEY=your_openai_api_key
-    API_KEY=your_api_token
-    PORT=8181
-    ```
-   The `API_KEY` value is used to authenticate admin actions. Once your server is running, visit `/login` and enter this token to enable creating or deleting posts and comments.
+3. **Set up environment variables**:
+   Create environment files for development and production.
+   
+   **.env.development**
+   ```bash
+   DATABASE_URI=your_postgres_database_url
+   OPENAI_API_KEY=your_openai_api_key
+   API_KEY=your_api_token
+   PORT=8181
+   VITE_API_URL=http://localhost:8181
+   VITE_ADMIN_ENABLED=true
+   ```
+   
+   **.env.production**
+   ```bash
+   DATABASE_URI=your_postgres_database_url
+   OPENAI_API_KEY=your_openai_api_key
+   PORT=8181
+   VITE_API_URL=https://your-production-url
+   VITE_ADMIN_ENABLED=false
+   ```
+   The `API_KEY` value is only included in development so you can test admin actions locally. Production builds omit this variable so public deployments cannot access admin routes or UI.
 
 4. **Run database migrations**:  
    Ensure your PostgreSQL server is running and execute:
@@ -144,7 +157,24 @@ The blog will now be accessible at `http://localhost:8181`.
 
 ### Admin Login
 
-Navigate to `http://localhost:8181/login` and enter the API key you placed in your `.env` file. Once logged in you can create or delete posts and comments from the UI.
+If `VITE_ADMIN_ENABLED` is set to `true`, navigate to `/login` and enter the token from `API_KEY` to unlock admin controls. This route and the related UI are removed in production where `VITE_ADMIN_ENABLED=false`.
+
+## Railway Deployment
+
+When deploying on [Railway](https://railway.app/), configure these environment variables:
+
+**Required**
+
+- `DATABASE_URI`
+- `OPENAI_API_KEY`
+- `PORT` (usually `8181`)
+- `VITE_API_URL` (your Railway app URL)
+- `VITE_ADMIN_ENABLED` (`false` for production)
+
+**Optional for development previews**
+
+- `API_KEY` (enables admin routes)
+- Set `VITE_ADMIN_ENABLED` to `true` if you include `API_KEY`
 
 ## Running Tests
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import Navbar from './components/NavBar'; // Navigation bar component
 import './App.css'
 
 const App = () => {
+  const isAdminEnabled = import.meta.env.VITE_ADMIN_ENABLED === 'true';
   return (
     <Router>
       <div>
@@ -18,7 +19,7 @@ const App = () => {
         {/* Define the routes */}
         <Routes>
           <Route path="/" element={<LandingPage />} />
-          <Route path="/login" element={<Login />} />
+          {isAdminEnabled && <Route path="/login" element={<Login />} />}
           <Route path="/posts" element={<BlogPosts />} />
           <Route path="/posts/:postId" element={<PostDetail />} />
           <Route path="/about" element={<About />} />

--- a/client/src/components/BlogPosts.jsx
+++ b/client/src/components/BlogPosts.jsx
@@ -10,6 +10,7 @@ const BlogPosts = () => {
     //state management
     const [posts, setPosts] = useState([]);
     const { token } = useContext(AuthContext);
+    const isAdminEnabled = import.meta.env.VITE_ADMIN_ENABLED === 'true';
    
     // Fetch posts on page load
     useEffect(() => {
@@ -51,11 +52,13 @@ const BlogPosts = () => {
                   <h2 className="post-title">{post.title}</h2>
                   <p className="post-author">By {post.author}</p>
                   <Link to={`/posts/${post.id}`} className="read-more">Read More</Link><br/>
-                  <button aria-label="delete post" className="delete-button" onClick={() => deletePost(post.id)} ><span role="img" aria-label="trash">🗑️</span></button>
+                  {isAdminEnabled && token && (
+                    <button aria-label="delete post" className="delete-button" onClick={() => deletePost(post.id)}><span role="img" aria-label="trash">🗑️</span></button>
+                  )}
               </li>
           ))}
       </ul>
-      {token && <CreatePost addNewPost={addNewPost}/>} 
+      {isAdminEnabled && token && <CreatePost addNewPost={addNewPost}/>}
   </div>
     )
 };

--- a/client/src/components/Comments.jsx
+++ b/client/src/components/Comments.jsx
@@ -10,6 +10,7 @@ const [newComment, setNewComment] = useState('')
 const [newAuthor, setNewAuthor] = useState('')
 const [isExpanded, setIsExpanded] = useState(false);
 const { token } = useContext(AuthContext);
+const isAdminEnabled = import.meta.env.VITE_ADMIN_ENABLED === 'true';
 
     useEffect(() => {
         const fetchCommentsByPostId = async () => {
@@ -117,7 +118,9 @@ const deleteComment = async (commentId, postId) => {
                     <p style={{ color: getSentimentColor(comment.sentiment_score)}}>{comment.content}</p>
                     <p><strong>Author:</strong> {comment.author}</p>
                   </li>
-                  <button className="comments-delete-button" onClick={() => deleteComment(comment.id, selectedPost)}>Delete</button>
+                  {isAdminEnabled && token && (
+                    <button className="comments-delete-button" onClick={() => deleteComment(comment.id, selectedPost)}>Delete</button>
+                  )}
                 </ul>
               ))
             ) : (

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -5,6 +5,7 @@ import styles from '../styles/Navbar.module.css';
 
 const Navbar = () => {
   const { token, logout } = useContext(AuthContext);
+  const isAdminEnabled = import.meta.env.VITE_ADMIN_ENABLED === 'true';
   return (
     <nav className={styles.nav}>
       <ul className={styles.list}>
@@ -17,13 +18,15 @@ const Navbar = () => {
         <li className={styles.item}>
           <Link className={styles.link} to="/about">About/Contact</Link>
         </li>
-        <li className={styles.item}>
-          {token ? (
-            <button className={styles.link} onClick={logout}>Logout</button>
-          ) : (
-            <Link className={styles.link} to="/login">Login</Link>
-          )}
-        </li>
+        {isAdminEnabled && (
+          <li className={styles.item}>
+            {token ? (
+              <button className={styles.link} onClick={logout}>Logout</button>
+            ) : (
+              <Link className={styles.link} to="/login">Login</Link>
+            )}
+          </li>
+        )}
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Summary
- guard admin features based on `VITE_ADMIN_ENABLED`
- add environment instructions for dev/prod builds
- document Railway variables
- ignore env files

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ff28ff7c83239493e0f9b16bc3b4