### PR TITLE
Fix newline rendering

### DIFF
--- a/client/src/components/PostDetail.jsx
+++ b/client/src/components/PostDetail.jsx
@@ -17,7 +17,9 @@ const [audioUrl, setAudioUrl] = useState(null);
         const response = await fetch(`${BASE_URL}/api/posts/${postId}`);
         const data = await response.json();
         console.log('Fetched post by ID:', data);
-        setPostById(data);
+        // Replace literal \n sequences with actual line breaks
+        const processedContent = data.content?.replace(/\\n/g, '\n');
+        setPostById({ ...data, content: processedContent });
       } catch (error) {
         console.error('Error fetching post:', error.message);
         throw error;

--- a/client/src/styles/PostDetail.css
+++ b/client/src/styles/PostDetail.css
@@ -42,6 +42,7 @@
   color: #555;
   line-height: 1.8;
   margin-bottom: 25px;
+  white-space: pre-line;
   text-align: justify;
   font-family: "Source Code Pro", monospace; /* Font consistency */
 }


### PR DESCRIPTION
## Summary
- parse `\n` escape sequences from posts on fetch
- render multiline post content with `white-space: pre-line`

## Testing
- `npm run test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685203b63e08832384f56abdf33e679e