### PR TITLE
Add resume component

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import LandingPage from './components/LandingPage';
 import BlogPosts from './components/BlogPosts';
 import PostDetail from './components/PostDetail';
 import About from './components/About';
+import Resume from './components/Resume';
 import Login from './components/Login';
 import Navbar from './components/NavBar'; // Navigation bar component
 import './App.css'
@@ -23,6 +24,7 @@ const App = () => {
           <Route path="/posts" element={<BlogPosts />} />
           <Route path="/posts/:postId" element={<PostDetail />} />
           <Route path="/about" element={<About />} />
+          <Route path="/resume" element={<Resume />} />
         </Routes>
       </div>
     </Router>

--- a/client/src/__test__/NavBar.test.jsx
+++ b/client/src/__test__/NavBar.test.jsx
@@ -9,8 +9,10 @@ describe('Navbar Component', () => {
     render( <MemoryRouter>
         <NavBar />
       </MemoryRouter>);
-
-   
+    expect(screen.getByRole('link', { name: /home/i })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /blog/i })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /resume/i })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /about\/contact/i })).toBeTruthy();
   });
 
 });

--- a/client/src/__test__/Resume.test.jsx
+++ b/client/src/__test__/Resume.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Resume from '../components/Resume';
+import { describe, it, expect } from 'vitest';
+
+describe('Resume Component', () => {
+  it('renders the resume page with key sections', () => {
+    render(
+      <MemoryRouter>
+        <Resume />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /michelle bedford-hunter/i })).toBeDefined();
+    expect(screen.getByText(/summary/i)).toBeTruthy();
+    expect(screen.getByText(/experience/i)).toBeTruthy();
+    expect(screen.getByText(/education/i)).toBeTruthy();
+    expect(screen.getByText(/skills/i)).toBeTruthy();
+  });
+});

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -16,6 +16,9 @@ const Navbar = () => {
           <Link className={styles.link} to="/posts">Blog</Link>
         </li>
         <li className={styles.item}>
+          <Link className={styles.link} to="/resume">Resume</Link>
+        </li>
+        <li className={styles.item}>
           <Link className={styles.link} to="/about">About/Contact</Link>
         </li>
         {isAdminEnabled && (

--- a/client/src/components/Resume.jsx
+++ b/client/src/components/Resume.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import '../styles/Resume.css';
+
+const Resume = () => {
+  return (
+    <div className="resume-page">
+      <h1 className="resume-name">Michelle Bedford-Hunter</h1>
+
+      <section className="resume-section">
+        <h2>Summary</h2>
+        <p>Passionate full-stack developer with a background in birth work. Seeking opportunities to build meaningful and accessible web applications.</p>
+      </section>
+
+      <section className="resume-section">
+        <h2>Experience</h2>
+        <ul>
+          <li>
+            <strong>Postpartum Doula</strong> – Supported families during the postpartum period, developing strong communication and problem-solving skills.
+          </li>
+          <li>
+            <strong>Software Developer</strong> – Created projects using React, Node.js and REST APIs while completing bootcamp coursework.
+          </li>
+        </ul>
+      </section>
+
+      <section className="resume-section">
+        <h2>Education</h2>
+        <ul>
+          <li>Full-Stack Web Development Bootcamp</li>
+          <li>Continuing self-study of modern web technologies</li>
+        </ul>
+      </section>
+
+      <section className="resume-section">
+        <h2>Skills</h2>
+        <p>JavaScript, React, Node.js, Express, SQL, HTML, CSS</p>
+      </section>
+    </div>
+  );
+};
+
+export default Resume;

--- a/client/src/styles/Resume.css
+++ b/client/src/styles/Resume.css
@@ -1,0 +1,35 @@
+@import url('https://fonts.googleapis.com/css2?family=Nothing+You+Could+Do&family=Shadows+Into+Light&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap');
+
+.resume-page {
+  padding: 50px;
+  background-color: var(--primary-bg);
+  font-family: 'Source Code Pro', monospace;
+  color: var(--primary-text);
+}
+
+.resume-name {
+  font-family: 'Nothing You Could Do', cursive;
+  font-size: 40px;
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.resume-section {
+  max-width: 800px;
+  margin: 0 auto 30px auto;
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.resume-section h2 {
+  font-family: 'Shadows Into Light', cursive;
+  font-size: 28px;
+  margin-bottom: 10px;
+  color: #13729a;
+}
+
+.resume-section ul {
+  padding-left: 20px;
+}


### PR DESCRIPTION
## Summary
- add resume component and styles
- include new route and navigation link
- verify navigation links via tests and add tests for resume

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685382dac1e0832398578dc6335ac3e0